### PR TITLE
sql: TestLogic/testdata equivalent for distsql [do not merge]

### DIFF
--- a/pkg/sql/testdata/distsql/order_by
+++ b/pkg/sql/testdata/distsql/order_by
@@ -1,0 +1,435 @@
+# ORDER BY expression tests.
+
+# DIST_SQL supports only read queries, CREATE TABLE/INSERT has to fall back to the
+# regular SQL implementation.
+
+statement ok
+SET DIST_SQL = ALWAYS
+
+statement ok
+SET DIST_SQL = OFF;
+CREATE TABLE t (
+  a INT PRIMARY KEY,
+  b INT,
+  c BOOLEAN
+);
+SET DIST_SQL = ALWAYS;
+
+statement ok
+SET DIST_SQL = OFF; INSERT INTO t VALUES (1, 9, true), (2, 8, false), (3, 7, NULL); SET DIST_SQL = ALWAYS;
+
+query B
+SELECT c FROM t ORDER BY c
+----
+NULL
+false
+true
+
+query B
+SELECT c FROM t ORDER BY c DESC
+----
+true
+false
+NULL
+
+query II
+SELECT a, b FROM t ORDER BY b
+----
+3 7
+2 8
+1 9
+
+# TODO(irfansharif): TBD what the equivalent of EXPLAIN would be in distsql.
+# query ITT
+# EXPLAIN SELECT a, b FROM t ORDER BY b
+# ----
+# 0 sort +b
+# 1 scan t@primary -
+
+query II
+SELECT a, b FROM t ORDER BY b DESC
+----
+1 9
+2 8
+3 7
+
+# query ITT
+# EXPLAIN SELECT a, b FROM t ORDER BY b DESC
+# ----
+# 0 sort -b
+# 1 scan t@primary -
+
+query I
+SELECT a FROM t ORDER BY 1 DESC
+----
+3
+2
+1
+
+# query ITT
+# EXPLAIN SELECT a, b FROM t ORDER BY b LIMIT 2
+# ----
+# 0 limit count: 2
+# 1 sort  +b (top 2)
+# 2 scan  t@primary -
+
+# TODO(irfansharif): These currently fail with 'limit not supported yet'.
+# query II
+# SELECT a, b FROM t ORDER BY b DESC LIMIT 2
+# ----
+# 1 9
+# 2 8
+
+# query ITT
+# EXPLAIN SELECT DISTINCT a FROM t ORDER BY b LIMIT 2
+# ----
+# 0 limit    count: 2
+# 1 distinct
+# 2 sort     +b (iterative)
+# 3 scan     t@primary -
+
+# query I
+# SELECT DISTINCT a FROM t ORDER BY b DESC LIMIT 2
+# ----
+# 1
+# 2
+
+query II
+SELECT a AS foo, b FROM t ORDER BY foo DESC
+----
+3 7
+2 8
+1 9
+
+query II
+SELECT a AS "foo.bar", b FROM t ORDER BY "foo.bar" DESC
+----
+3 7
+2 8
+1 9
+
+query II
+SELECT a AS foo, b FROM t ORDER BY a DESC
+----
+3 7
+2 8
+1 9
+
+query I
+SELECT b FROM t ORDER BY a DESC
+----
+7
+8
+9
+
+# query ITT
+# EXPLAIN SELECT b FROM t ORDER BY a DESC
+# ----
+# 0 nosort -a
+# 1 revscan t@primary -
+
+# query ITT
+# EXPLAIN SELECT b FROM t ORDER BY a DESC, b ASC
+# ----
+# 0 nosort -a,+b
+# 1 revscan t@primary -
+ 
+# query ITT
+# EXPLAIN SELECT b FROM t ORDER BY a DESC, b DESC
+# ----
+# 0 nosort -a,-b
+# 1 revscan t@primary -
+
+statement ok
+SET DIST_SQL = OFF; INSERT INTO t VALUES (4, 7), (5, 7); SET DIST_SQL = ALWAYS;
+
+query II
+SELECT a, b FROM t WHERE b = 7 ORDER BY b, a
+----
+3 7
+4 7
+5 7
+
+query II
+SELECT a, b FROM t ORDER BY b, a DESC
+----
+5 7
+4 7
+3 7
+2 8
+1 9
+
+query III
+SELECT a, b, a+b AS ab FROM t WHERE b = 7 ORDER BY ab DESC, a
+----
+5 7 12
+4 7 11
+3 7 10
+
+query I
+SELECT a FROM t ORDER BY a+b DESC, a
+----
+5
+4
+1
+2
+3
+
+query I
+SELECT a FROM t ORDER BY (((a)))
+----
+1
+2
+3
+4
+5
+
+# TODO(irfansharif): These currently fail with 'limit not supported yet'.
+# query I
+# (((SELECT a FROM t))) ORDER BY a DESC LIMIT 4
+# ----
+# 5
+# 4
+# 3
+# 2
+
+# query I
+# (((SELECT a FROM t ORDER BY a DESC LIMIT 4)))
+# ----
+# 5
+# 4
+# 3
+# 2
+
+query error multiple ORDER BY clauses not allowed
+((SELECT a FROM t ORDER BY a)) ORDER BY a
+
+query error expected c to be of type int, found type bool
+SELECT CASE a WHEN 1 THEN b ELSE c END as val FROM t ORDER BY val
+
+query error invalid column index: 0 not in range \[1, 3\]
+SELECT * FROM t ORDER BY 0
+
+query error non-integer constant column index: true
+SELECT * FROM t ORDER BY true
+
+query error column name "foo" not found
+SELECT * FROM t ORDER BY foo
+
+query error source name "a" not found in FROM clause
+SELECT a FROM t ORDER BY a.b
+
+statement ok
+SET DIST_SQL = OFF;
+CREATE TABLE abc (
+  a INT,
+  b INT,
+  c INT,
+  d CHAR,
+  PRIMARY KEY (a, b, c),
+  UNIQUE INDEX bc (b, c),
+  INDEX ba (b, a),
+  FAMILY (a, b, c),
+  FAMILY (d)
+);
+SET DIST_SQL = ALWAYS;
+
+statement ok
+SET DIST_SQL = OFF; INSERT INTO abc VALUES (1, 2, 3, 'one'), (4, 5, 6, 'Two'); SET DIST_SQL = ALWAYS;
+
+query T
+SELECT d FROM abc ORDER BY LOWER(d)
+----
+one
+Two
+
+# query ITTT
+# EXPLAIN (DEBUG) SELECT * FROM abc ORDER BY a
+# ----
+# 0 /abc/primary/1/2/3   NULL  PARTIAL
+# 0 /abc/primary/1/2/3/d 'one' ROW
+# 1 /abc/primary/4/5/6   NULL  PARTIAL
+# 1 /abc/primary/4/5/6/d 'Two' ROW
+
+# query ITT
+# EXPLAIN SELECT * FROM abc ORDER BY a
+# ----
+# 0 scan abc@primary -
+
+# query ITTT
+# EXPLAIN (DEBUG) SELECT a, b FROM abc ORDER BY b, a
+# ----
+# 0 /abc/ba/2/1/3 NULL ROW
+# 1 /abc/ba/5/4/6 NULL ROW
+
+# query ITT
+# EXPLAIN SELECT a, b FROM abc ORDER BY b, a
+# ----
+# 0 scan abc@ba -
+
+# The non-unique index ba includes column c (required to make the keys unique)
+# so the results will already be sorted.
+# query ITT
+# EXPLAIN SELECT a, b, c FROM abc ORDER BY b, a, c
+# ----
+# 0 scan abc@ba -
+
+# We use the WHERE condition to force the use of index ba.
+# query ITT
+# EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 ORDER BY b, a, d
+# ----
+# 0 sort       +b,+a,+d
+# 1 index-join
+# 2 scan       abc@ba /11-
+# 2 scan       abc@primary
+
+# We cannot have rows with identical values for a,b,c so we don't need to
+# sort for d.
+# query ITT
+# EXPLAIN SELECT a, b, c, d FROM abc WHERE b > 10 ORDER BY b, a, c, d
+# ----
+# 0 index-join
+# 1 scan       abc@ba /11-
+# 1 scan       abc@primary
+
+# query ITT
+# EXPLAIN SELECT a, b FROM abc ORDER BY b, c
+# ----
+# 0 nosort +b,+c
+# 1 scan   abc@bc -
+
+# query ITT
+# EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
+# ----
+# 0 nosort +b,+c,+a
+# 1 scan   abc@bc -
+
+# query ITT
+# EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a DESC
+# ----
+# 0 nosort +b,+c,-a
+# 1 scan   abc@bc -
+
+# query ITTT
+# EXPLAIN (DEBUG) SELECT b, c FROM abc ORDER BY b, c
+# ----
+# 0 /abc/bc/2/3 /1 ROW
+# 1 /abc/bc/5/6 /4 ROW
+
+# query ITTT
+# EXPLAIN (DEBUG) SELECT a, b, c FROM abc ORDER BY b
+# ----
+# 0 /abc/bc/2/3 /1 ROW
+# 1 /abc/bc/5/6 /4 ROW
+
+# query ITTT
+# EXPLAIN (DEBUG) SELECT a FROM abc ORDER BY a DESC
+# ----
+# 0 /abc/primary/4/5/6/d 'Two' PARTIAL
+# 0 /abc/primary/4/5/6   NULL  ROW
+# 1 /abc/primary/1/2/3/d 'one' PARTIAL
+# 1 /abc/primary/1/2/3   NULL  ROW
+
+# query ITT
+# EXPLAIN SELECT a FROM abc ORDER BY a DESC
+# ----
+# 0 revscan abc@primary -
+
+query I
+SELECT a FROM abc ORDER BY a DESC
+----
+4
+1
+
+# TODO(irfansharif): These currently fail with 'limit not supported yet'.
+# query I
+# SELECT a FROM abc ORDER BY a DESC LIMIT 1
+# ----
+# 4
+
+# query I
+# SELECT a FROM abc ORDER BY a DESC OFFSET 1
+# ----
+# 1
+
+# query ITT
+# EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c
+# ----
+# 0 scan abc@bc /2-/3
+
+# query ITT
+# EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
+# ----
+# 0 revscan abc@bc /2-/3
+
+statement ok
+SET DIST_SQL = OFF; CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz)); SET DIST_SQL = ALWAYS;
+
+statement ok
+SET DIST_SQL = OFF; INSERT INTO bar VALUES (0, NULL), (1, NULL); SET DIST_SQL = ALWAYS;
+
+query IT
+SELECT * FROM bar ORDER BY baz, id;
+----
+0 NULL
+1 NULL
+
+statement ok
+SET DIST_SQL = OFF;
+CREATE TABLE abcd (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT,
+  INDEX abc (a, b, c)
+);
+SET DIST_SQL = ALWAYS;
+
+statement ok
+SET DIST_SQL = OFF; INSERT INTO abcd VALUES (1, 4, 2, 3), (2, 3, 4, 1), (3, 2, 1, 2), (4, 4, 1, 1); SET DIST_SQL = ALWAYS;
+
+# The following tests verify we recognize that sorting is not necessary
+# query ITT
+# EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
+# ----
+# 0 scan abcd@abc /1/4-/1/5
+
+# query ITT
+# EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
+# ----
+# 0 scan abcd@abc /1/4-/1/5
+
+# query ITT
+# EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
+# ----
+# 0 scan abcd@abc /1/4-/1/5
+
+# query ITT
+# EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
+# ----
+# 0 scan abcd@abc /1/4-/1/5
+
+statement ok
+SET DIST_SQL = OFF; CREATE TABLE nan (id INT PRIMARY KEY, x REAL); SET DIST_SQL = ALWAYS;
+
+statement ok
+SET DIST_SQL = OFF; INSERT INTO nan VALUES (1, 0/0), (2, -1), (3, 1), (4, 0/0); SET DIST_SQL = ALWAYS;
+
+query R
+SELECT x FROM nan ORDER BY x;
+----
+NaN
+NaN
+-1
+1
+
+# query ITTTT
+# EXPLAIN(VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x);
+# ----
+# 0  select                           (x)        +x
+# 1  render/filter  from (""."".x)    (x)        +x
+# 2  select                           (x)        +x
+# 3  sort           +x                (x)        +x
+# 4  render/filter  from ("".c.x)     (x)
+# 5  select                           (column1)
+# 6  values         1 column, 3 rows  (column1)

--- a/pkg/sql/testdata/distsql/select
+++ b/pkg/sql/testdata/distsql/select
@@ -1,0 +1,333 @@
+# SELECT expression tests.
+
+# DIST_SQL supports only read queries, CREATE TABLE/INSERT has to fall back to the
+# regular SQL implementation.
+# TODO(irfansharif): CREATE/INSERT or really any non-read-only queries should
+# automatically default to non-distsql.
+
+
+statement ok
+SET DIST_SQL = ALWAYS
+
+# TODO(irfansharif): These currently fail with 'unsupported node *sql.emptyNode'
+# SELECT with no table.
+
+# query I
+# SELECT 1
+# ----
+# 1
+
+# query II colnames
+# SELECT 1+1 AS two, 2+2 AS four
+# ----
+# two four
+# 2   4
+
+# SELECT expression tests.
+
+statement ok
+SET DIST_SQL = OFF; CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT); SET DIST_SQL = ALWAYS;
+
+query error syntax error at or near \"FROM\"
+SELECT FROM abc
+
+query error argument of WHERE must be type bool, not type string
+SELECT * FROM abc WHERE 'hello'
+
+statement ok
+SET DIST_SQL = OFF; INSERT INTO abc VALUES (1, 2, 3); SET DIST_SQL = ALWAYS;
+
+query III colnames
+SELECT * FROM abc
+----
+a b c
+1 2 3
+
+# synonym for SELECT * FROM abc
+query III
+TABLE abc
+----
+1 2 3
+
+query error invalid table name
+TABLE abc[TRUE]
+
+query error invalid table name
+TABLE abc.*
+
+query III colnames
+SELECT * FROM abc WHERE NULL
+----
+a b c
+
+query III colnames
+SELECT * FROM abc WHERE a = NULL
+----
+a b c
+
+query IIIIII colnames
+SELECT *,* FROM abc
+----
+a b c a b c
+1 2 3 1 2 3
+
+query IIII colnames
+SELECT a,a,a,a FROM abc
+----
+a a a a
+1 1 1 1
+
+query II colnames
+SELECT a,c FROM abc
+----
+a c
+1 3
+
+query I colnames
+SELECT a+b+c AS foo FROM abc
+----
+foo
+6
+
+statement ok
+SET DIST_SQL = OFF; INSERT INTO abc VALUES (0, 1, 2); SET DIST_SQL = ALWAYS;
+
+query II
+SELECT a,b FROM abc WHERE CASE WHEN a != 0 THEN b/a > 1.5 ELSE false END
+----
+1 2
+
+# SELECT of NULL value.
+
+statement ok
+SET DIST_SQL = OFF; CREATE TABLE kv (k CHAR PRIMARY KEY, v CHAR); SET DIST_SQL = ALWAYS;
+
+statement ok
+SET DIST_SQL = OFF; INSERT INTO kv (k) VALUES ('a'); SET DIST_SQL = ALWAYS;
+
+query TT
+SELECT * FROM kv
+----
+a NULL
+
+query TT
+SELECT k,v FROM kv
+----
+a NULL
+
+query T
+SELECT v||'foo' FROM kv
+----
+NULL
+
+query T
+SELECT LOWER(v) FROM kv
+----
+NULL
+
+query T
+SELECT k FROM kv
+----
+1 value hashing to 60b725f10c9c85c70d97880dfe8191b3
+
+query TT
+SELECT kv.K,KV.v FROM kv
+----
+a NULL
+
+query TT
+SELECT kv.* FROM kv
+----
+a NULL
+
+query error source name "foo" not found in FROM clause
+SELECT foo.* FROM kv
+
+query error cannot use "\*" without a FROM clause
+SELECT *
+
+# "*" must expand to zero columns if there are zero columns to select.
+statement ok
+SET DIST_SQL = OFF; CREATE TABLE nocols(x INT); ALTER TABLE nocols DROP COLUMN x; SET DIST_SQL = ALWAYS;
+
+query I
+SELECT 1, * FROM nocols
+----
+
+query error "kv.*" cannot be aliased
+SELECT kv.* AS foo FROM kv
+
+query error table "bar.kv" not selected in FROM clause
+SELECT bar.kv.* FROM kv
+
+# Don't panic with invalid names (#8024)
+query error invalid column name: "kv.*"
+SELECT kv.*[1] FROM kv
+
+query T colnames
+SELECT FOO.k FROM kv AS foo WHERE foo.k = 'a'
+----
+k
+a
+
+query T
+SELECT "Foo"."V" FROM kv AS foo WHERE foo.k = 'a'
+----
+NULL
+
+statement ok
+SET DIST_SQL = OFF; CREATE TABLE kw ("from" INT PRIMARY KEY); SET DIST_SQL = ALWAYS;
+
+statement ok
+SET DIST_SQL = OFF; INSERT INTO kw VALUES (1); SET DIST_SQL = ALWAYS;
+
+query III colnames
+SELECT *, "from", kw."from" FROM kw
+----
+from from from
+1    1    1
+
+# SELECT from index, LIMIT/OFFSET.
+# TODO(irfansharif): These currently fail with 'limit not supported yet'.
+
+statement ok
+SET DIST_SQL = OFF;
+CREATE TABLE xyzw (
+  x INT PRIMARY KEY,
+  y INT,
+  z INT,
+  w INT,
+  INDEX foo (z, y)
+);
+SET DIST_SQL = ALWAYS;
+
+statement ok
+SET DIST_SQL = OFF; INSERT INTO xyzw VALUES (4, 5, 6, 7), (1, 2, 3, 4); SET DIST_SQL = ALWAYS;
+
+# query error name \"x\" is not defined
+# SELECT * FROM xyzw LIMIT x
+
+# query error name \"y\" is not defined
+# SELECT * FROM xyzw OFFSET 1 + y
+
+# query error argument of LIMIT must be type int, not type string
+# SELECT * FROM xyzw LIMIT '1'
+
+# query error argument of OFFSET must be type int, not type decimal
+# SELECT * FROM xyzw OFFSET 1.5
+
+# query error negative value for LIMIT
+# SELECT * FROM xyzw LIMIT -100
+
+# query error negative value for OFFSET
+# SELECT * FROM xyzw OFFSET -100
+
+# query IIII
+# SELECT * FROM xyzw OFFSET 1 + 0.0
+# ----
+# 4 5 6 7
+
+# TODO(irfansharif): This currently fails with 'unsupported render type
+# tuple{int, int}'
+# query T
+# SELECT (x,y) FROM xyzw
+# ----
+# (1,2)
+# (4,5)
+
+# query IIII
+# SELECT * FROM xyzw LIMIT 0
+# ----
+
+# query IIII
+# SELECT * FROM xyzw LIMIT 1
+# ----
+# 1 2 3 4
+
+# query IIII
+# SELECT * FROM xyzw LIMIT 1 OFFSET 1
+# ----
+# 4 5 6 7
+
+# Multiplying by zero so the result is deterministic.
+# query IIII
+# SELECT * FROM xyzw LIMIT (RANDOM() * 0.0)::int OFFSET (RANDOM() * 0.0)::int
+# ----
+
+# query error multiple LIMIT clauses not allowed
+# ((SELECT a FROM t LIMIT 1)) LIMIT 1
+
+query II
+SELECT z, y FROM xyzw@foo
+----
+3 2
+6 5
+
+query I
+SELECT z FROM test.xyzw@foo WHERE y = 5
+----
+6
+
+query I
+SELECT xyzw.y FROM test.xyzw@foo WHERE z = 3
+----
+2
+
+query error table "test.unknown" does not exist
+SELECT z FROM test.unknown@foo WHERE y = 5
+
+query error index "unknown" not found
+SELECT z FROM test.xyzw@unknown WHERE y = 5
+
+query I
+SELECT w FROM test.xyzw@foo WHERE y = 5
+----
+7
+
+statement ok
+SET DIST_SQL = OFF;
+CREATE TABLE boolean_table (
+  id INTEGER PRIMARY KEY NOT NULL,
+  value BOOLEAN
+);
+SET DIST_SQL = ALWAYS;
+
+statement ok
+SET DIST_SQL = OFF; INSERT INTO boolean_table (id, value) VALUES (1, NULL); SET DIST_SQL = ALWAYS;
+
+query I
+SELECT value FROM boolean_table
+----
+NULL
+
+# TODO(irfansharif): This currently fails with 'unsupported node *sql.emptyNode'
+# query I
+# SELECT CASE WHEN NULL THEN 1 ELSE 2 END
+# ----
+# 2
+
+statement ok
+SET DIST_SQL = OFF; INSERT INTO abc VALUES (42, NULL, NULL); SET DIST_SQL = ALWAYS;
+
+query III
+SELECT 0 * b, b % 1, 0 % b from abc
+----
+0 0 0
+0 0 0
+NULL NULL NULL
+
+# Doing an index lookup by MaxInt used to not work.
+# https://github.com/cockroachdb/cockroach/issues/3587
+statement ok
+SET DIST_SQL = OFF; CREATE TABLE MaxIntTest (a INT PRIMARY KEY); SET DIST_SQL = ALWAYS;
+
+statement ok
+SET DIST_SQL = OFF; INSERT INTO MaxIntTest VALUES (9223372036854775807); SET DIST_SQL = ALWAYS;
+
+query I
+SELECT a FROM MaxIntTest WHERE a = 9223372036854775807
+----
+9223372036854775807
+
+query error no value provided for placeholder
+SELECT $1::int

--- a/pkg/sql/testdata/set
+++ b/pkg/sql/testdata/set
@@ -115,3 +115,11 @@ SET APPLICATION_NAME = 'hello'
 statement ok
 SET EXTRA_FLOAT_DIGITS = 3
 
+statement ok
+SET DIST_SQL = ALWAYS
+
+statement ok
+SET DIST_SQL = OFF
+
+statement ok
+SET DIST_SQL = ON


### PR DESCRIPTION
This is experimental work in trying to automate testing of our distsql
work, what this introduces is essentially `TestLogic` for distsql.

Caveat: We should be sure to not add new tests to `testdata/distsql` to
        avoid divergence between the equivalent test under `testdata/`.

Running only distsql tests:
  ```
  make test PKG=./pkg/sql TESTS=TestLogic \
    TESTFLAGS='-v -d testdata/distsql/*'
  ```

Takeaways:
  - The need for an equivalent for `EXPLAIN` in distsql, detailing out
  the physical plan.
  - `CREATE`/`INSERT` or really any non-read-only queries should
  automatically default to non-distsql.
  - `*sql.emptyNode` doesn't have an equivalent in distsql yet.
  - Limit unsupported (this is already being tracked).
  - Unsupported render type tuple.

cc @knz @andreimatei @cuongdo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/raduberinde/cockroach/17)
<!-- Reviewable:end -->
